### PR TITLE
🐛 Fix issue #40 with the gallery login

### DIFF
--- a/src/server/routes/gallery.js
+++ b/src/server/routes/gallery.js
@@ -9,8 +9,12 @@ async function post(req, res) {
     const userIP = req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.socket.remoteAddress || req.connection.socket.remoteAddress;
     res.setHeader('Content-Type', 'text/html');
     const protocol = this.protocol();
-    const password = this.c.admin.key;
-    if (req.body.password !== this.c.admin.key) {
+    var password = this.c.admin.key;
+    // Compatibility with old config
+    if(typeof password == "string"){
+      password = [password];
+    }
+    if (!this.c.admin.key.includes(req.body.password)) {
         res.statusCode = 401;
         res.render('unauthorized');
         res.end();


### PR DESCRIPTION
The problem was easy to fix, on [`src/server/routes/gallery.js`](https://github.com/TannerReynolds/ShareX-Upload-Server/blob/1f1019d59fcab3625813e61ddedfb4bcff504dff/src/server/routes/gallery.js#L13) you checked if the password is equal to `this.c.admin.key`, but [`this.c.admin.key` is an array](https://github.com/TannerReynolds/ShareX-Upload-Server/blob/1f1019d59fcab3625813e61ddedfb4bcff504dff/src/config.json#L19), I made it compatible with the new config & also with the [old one](https://github.com/TannerReynolds/ShareX-Upload-Server/commit/3d3c6d01788e0c7994e41da02b801eeaba484cdb#diff-5ca1cd5bde62416d7f8469f969948a94L18-R18).
