### PR TITLE
Old ExifTool url - 404 Not Found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,9 +19,9 @@ if which node > /dev/null
 fi
 cd src && npm i -g pm2
 cd src && npm i
-wget https://exiftool.org/Image-ExifTool-11.80.tar.gz
-tar xvf Image-ExifTool-11.80.tar.gz
-cd Image-ExifTool-11.80
+wget https://exiftool.org/Image-ExifTool-12.30.tar.gz
+tar xvf Image-ExifTool-12.30.tar.gz
+cd Image-ExifTool-12.30
 perl Makefile.PL
 make
 make test


### PR DESCRIPTION
The download address no longer exists and returns an HTTP error 404. Update to the latest available version.