### PR TITLE
Fix ERR_ILLEGAL_FILE_TYPE page render

### DIFF
--- a/src/server/routes/illegalFileType.js
+++ b/src/server/routes/illegalFileType.js
@@ -1,7 +1,7 @@
 async function illegalFileType(req, res) {
     res.setHeader('Content-Type', 'text/html');
     res.statusCode = 413;
-    res.render('ERR_FILE_TOO_BIG');
+    res.render('ERR_ILLEGAL_FILE_TYPE');
     res.end();
 }
 module.exports = illegalFileType;


### PR DESCRIPTION
Make it so if an illegal file type is uploaded, the "ERR_ILLEGAL_FILE_TYPE" view is shown to the user and not the one about a payload that is too big.